### PR TITLE
Add support for .marko.html templates

### DIFF
--- a/bin/markoc.js
+++ b/bin/markoc.js
@@ -242,7 +242,7 @@ if (args.clean) {
             file: function(file, context) {
                 var basename = nodePath.basename(file);
 
-                if (basename.endsWith('.marko.js') || basename.endsWith('.marko.xml.js')) {
+                if (basename.endsWith('.marko.js') || basename.endsWith('.marko.html') || basename.endsWith('.marko.xml.js')) {
                     context.beginAsync();
                     fs.unlink(file, function(err) {
                         if (err) {
@@ -314,7 +314,7 @@ if (args.clean) {
                 file: function(file, context) {
                     var basename = nodePath.basename(file);
 
-                    if (basename.endsWith('.marko') || basename.endsWith('.marko.xml')) {
+                    if (basename.endsWith('.marko') || basename.endsWith('.marko.html') || basename.endsWith('.marko.xml')) {
                         compile(file, context);
                     }
                 }

--- a/compiler/taglibs/taglib-loader.js
+++ b/compiler/taglibs/taglib-loader.js
@@ -305,22 +305,21 @@ function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, taglib) {
                 tag = buildTag(tagDef, tagsConfigPath, taglib, tagDirname);
                 tag.name = childFilename;
                 taglib.addTag(tag);
-            } else if (fs.existsSync(templateFile)) {
-                var templateCode = fs.readFileSync(templateFile, {encoding: 'utf8'});
+            } else {
+                var templateCode;
+                if (fs.existsSync(templateFile)) {
+                    templateCode = fs.readFileSync(templateFile, {encoding: 'utf8'});
+                }
+                else if (fs.existsSync(templateFile + ".html")){
+                    templateFile = templateFile + ".html";
+                    templateCode = fs.readFileSync(templateFile, {encoding: 'utf8'});
+                }
                 tagDef = tagDefFromCode.extractTagDef(templateCode);
                 if (!tagDef) {
                      tagDef = createDefaultTagDef();
                 }
 
                 tagDef.template = templateFile;
-            } else if (fs.existsSync(templateFile + ".html")) {
-                var templateCode = fs.readFileSync(templateFile + ".html", {encoding: 'utf8'});
-                tagDef = tagDefFromCode.extractTagDef(templateCode);
-                if (!tagDef) {
-                    tagDef = createDefaultTagDef();
-                }
-
-                tagDef.template = templateFile + ".html";
             }
 
             if (tagDef) {

--- a/compiler/taglibs/taglib-loader.js
+++ b/compiler/taglibs/taglib-loader.js
@@ -306,20 +306,22 @@ function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, taglib) {
                 tag.name = childFilename;
                 taglib.addTag(tag);
             } else {
-                var templateCode;
+                var exTemplateFile;
                 if (fs.existsSync(templateFile)) {
-                    templateCode = fs.readFileSync(templateFile, {encoding: 'utf8'});
+                    exTemplateFile = templateFile;
                 }
                 else if (fs.existsSync(templateFile + ".html")){
-                    templateFile = templateFile + ".html";
-                    templateCode = fs.readFileSync(templateFile, {encoding: 'utf8'});
+                    exTemplateFile = templateFile + ".html";
                 }
-                tagDef = tagDefFromCode.extractTagDef(templateCode);
-                if (!tagDef) {
-                     tagDef = createDefaultTagDef();
-                }
+                if(exTemplateFile){
+                    var templateCode = fs.readFileSync(exTemplateFile, {encoding: 'utf8'});
+                    tagDef = tagDefFromCode.extractTagDef(templateCode);
+                    if (!tagDef) {
+                        tagDef = createDefaultTagDef();
+                    }
 
-                tagDef.template = templateFile;
+                    tagDef.template = exTemplateFile;
+                }
             }
 
             if (tagDef) {

--- a/compiler/taglibs/taglib-loader.js
+++ b/compiler/taglibs/taglib-loader.js
@@ -280,6 +280,8 @@ function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, taglib) {
                     tagDef.renderer = rendererFile;
                 } else if (fs.existsSync(templateFile)) {
                     tagDef.template = templateFile;
+                } else if (fs.existsSync(templateFile + ".html")) {
+                    tagDef.template = templateFile + ".html";
                 } else {
                     throw new Error('Invalid tag file: ' + tagFile + '. Neither a renderer or a template was found for tag.');
                 }
@@ -311,6 +313,14 @@ function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, taglib) {
                 }
 
                 tagDef.template = templateFile;
+            } else if (fs.existsSync(templateFile + ".html")) {
+                var templateCode = fs.readFileSync(templateFile + ".html", {encoding: 'utf8'});
+                tagDef = tagDefFromCode.extractTagDef(templateCode);
+                if (!tagDef) {
+                    tagDef = createDefaultTagDef();
+                }
+
+                tagDef.template = templateFile + ".html";
             }
 
             if (tagDef) {

--- a/hot-reload/index.js
+++ b/hot-reload/index.js
@@ -60,13 +60,14 @@ exports.handleFileModified = function(path) {
     var basename = nodePath.basename(path);
 
     if (path.endsWith('.marko') ||
+        path.endsWith('.marko.html') ||
         path.endsWith('.marko.xml') ||
         basename === 'marko-tag.json' ||
         basename === 'marko-taglib.json') {
 
         console.log('[marko/hot-reload] File modified: ' + path);
 
-        if (path.endsWith('.marko')) {
+        if (path.endsWith('.marko') || path.endsWith('.marko.html')) {
             delete require.cache[path + '.js'];
         }
 

--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -5,7 +5,7 @@ var extend = require('raptor-util/extend');
 var attr = require('raptor-util/attr');
 var attrs = require('raptor-util/attrs');
 var forEach = require('raptor-util/forEach');
-var markoRegExp = /\.marko(.xml)?$/;
+var markoRegExp = /\.marko(.xml|.html)?$/;
 var req = require;
 
 function notEmpty(o) {


### PR DESCRIPTION
There are several use-cases where you’d want .html files instead of .marko files. So I’ve added support for „.marko.html“ files.