### PR TITLE
be less permissive when looking for entities to decode

### DIFF
--- a/compiler/ParseTreeBuilderHtml.js
+++ b/compiler/ParseTreeBuilderHtml.js
@@ -32,7 +32,7 @@ var entities = {
 };
 
 function decodeEntities(data) {
-    return data.replace(/&([^;]+);/g, function(match, entityName) {
+    return data.replace(/&([a-z0-9#]+);/gi, function(match, entityName) {
         return entities[entityName] || '${entity:' + entityName + '}';
     });
 }


### PR DESCRIPTION
This template fails compilation:
```
<script>
  var x = '${x}?y=z&a=';
  var x = '${x}?y=z&a=';
</script>
```
While this one compiles:
```
<script>
  var x = '${x}?y=z&a=';
</script>
```
Debugging points to an overly-permissive regular expression used to locate HTML entities.  This patch modifies the expression to be stricter about what it matches.