### PR TITLE
further tighten entity-matching regex, add basic test for entity matching

### DIFF
--- a/compiler/ParseTreeBuilderHtml.js
+++ b/compiler/ParseTreeBuilderHtml.js
@@ -32,7 +32,8 @@ var entities = {
 };
 
 function decodeEntities(data) {
-    return data.replace(/&([a-z0-9#]+);/gi, function(match, entityName) {
+    // match numeric, hexadecimal & named entities
+    return data.replace(/&(#\d+|#x[0-9a-fA-F]+|[a-zA-Z0-9]+);/g, function(match, entityName) {
         return entities[entityName] || '${entity:' + entityName + '}';
     });
 }

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -58,6 +58,10 @@ describe('marko/compiler' , function() {
         testCompiler('fixtures/templates/compiler/hello-dynamic');
     });
 
+    it('should compile a simple template with entities', function() {
+        testCompiler('fixtures/templates/compiler/entities');
+    });
+
     // it.only('should compile a template with <c:invoke>', function() {
     //     testCompiler('test-project/tabs.marko');
     // });

--- a/test/fixtures/templates/compiler/entities/expected.js
+++ b/test/fixtures/templates/compiler/entities/expected.js
@@ -1,0 +1,9 @@
+exports.create = function(__helpers) {
+  var str = __helpers.s,
+      empty = __helpers.e,
+      notEmpty = __helpers.ne;
+
+  return function render(data, out) {
+    out.w('Hello John &amp; Suzy Invalid Entity: &amp;b ; Valid Numeric Entity: &#34;\nValid Hexadecimal Entity:\n&#x00A2;');
+  };
+}

--- a/test/fixtures/templates/compiler/entities/template.marko
+++ b/test/fixtures/templates/compiler/entities/template.marko
@@ -1,0 +1,4 @@
+Hello John &amp; Suzy
+Invalid Entity: &b ;
+Valid Numeric Entity: &#34;
+Valid Hexadecimal Entity: &#x00A2;


### PR DESCRIPTION
This tightens the entity matching regular expression to explicitly handle numeric and hexadecimal entities separately from named entities.  It also adds a simple test that entities are being properly matched.