### PR TITLE
Fixes #73 - Prevent same taglib from being loaded multiple times

### DIFF
--- a/compiler/taglibs/Taglib/index.js
+++ b/compiler/taglibs/Taglib/index.js
@@ -18,9 +18,9 @@
 var forEachEntry = require('raptor-util').forEachEntry;
 var ok = require('assert').ok;
 
-function Taglib(id) {
-    ok(id, '"id" expected');
-    this.id = id;
+function Taglib(path) {
+    ok(path, '"path" expected');
+    this.path = path;
     this.dirname = null;
     this.tags = {};
     this.textTransformers = [];

--- a/compiler/taglibs/taglib-lookup.js
+++ b/compiler/taglibs/taglib-lookup.js
@@ -20,8 +20,12 @@ function buildLookup(dirname) {
 	var lookup = lookupCache[lookupCacheKey];
 	if (lookup === undefined) {
 		lookup = new TaglibLookup();
-
-        for (var i=taglibs.length-1; i>=0; i--) {
+		// The taglibs "closer" to the template will be earlier in the list
+		// and the taglibs "farther" from the template will be later. We
+		// want closer taglibs to take precedence (especially when de-duping)
+		// so we loop from beginning to end. We used to loop from the end
+		// to the beginning, but that appears to have been a mistake.
+        for (var i=0; i<taglibs.length; i++) {
 			var taglib = taglibs[i];
 			lookup.addTaglib(taglib);
 

--- a/taglibs/caching/marko-taglib.json
+++ b/taglibs/caching/marko-taglib.json
@@ -1,4 +1,5 @@
 {
+    "taglib-id": "marko-caching",
     "tags": {
         "cached-fragment": {
             "renderer": "./cached-fragment-tag",

--- a/taglibs/core/marko-taglib.json
+++ b/taglibs/core/marko-taglib.json
@@ -1,4 +1,5 @@
 {
+    "taglib-id": "marko-core",
     "tags": {
         "c-template": {
             "attributes": {

--- a/taglibs/html/marko-taglib.json
+++ b/taglibs/html/marko-taglib.json
@@ -1,4 +1,5 @@
 {
+    "taglib-id": "marko-html",
     "tags": {
         "html": {
             "attributes": {

--- a/test/fixtures/taglib-duplicate/foo-renderer.js
+++ b/test/fixtures/taglib-duplicate/foo-renderer.js
@@ -1,0 +1,3 @@
+exports.render = function(input, out) {
+
+};

--- a/test/fixtures/taglib-duplicate/marko-taglib.json
+++ b/test/fixtures/taglib-duplicate/marko-taglib.json
@@ -1,0 +1,6 @@
+{
+    "taglib-id": "taglib-duplicate",
+    "<duplicate-foo>": {
+        "renderer": "./foo-renderer.js"
+    }
+}

--- a/test/fixtures/taglib-duplicate/taglib-duplicate/bar-renderer.js
+++ b/test/fixtures/taglib-duplicate/taglib-duplicate/bar-renderer.js
@@ -1,0 +1,3 @@
+exports.render = function(input, out) {
+
+};

--- a/test/fixtures/taglib-duplicate/taglib-duplicate/marko-taglib.json
+++ b/test/fixtures/taglib-duplicate/taglib-duplicate/marko-taglib.json
@@ -1,0 +1,6 @@
+{
+    "taglib-id": "taglib-duplicate",
+    "<duplicate-bar>": {
+        "renderer": "./bar-renderer.js"
+    }
+}

--- a/test/taglib-lookup-test.js
+++ b/test/taglib-lookup-test.js
@@ -182,4 +182,20 @@ describe('taglib-lookup' , function() {
         expect(transformers[2].path.indexOf('html-tag-transformer')).to.not.equal(-1);
     });
 
+    it('should de-duplicate taglibs', function() {
+        var taglibLookup = require('../compiler').taglibs.lookup;
+        var lookup = taglibLookup.buildLookup(nodePath.join(__dirname, 'fixtures/taglib-duplicate/taglib-duplicate'));
+
+        // The "duplicate-bar" tag was declared in the lower
+        // taglib so it should have been found since the taglib
+        // should not have been de-duped.
+        var barTag = lookup.getTag('duplicate-bar');
+        expect(barTag != null).to.equal(true);
+
+        // The "duplicate-foo" tag was declared in the higher
+        // up taglib so it should have been discarded
+        var fooTag = lookup.getTag('duplicate-foo');
+        expect(fooTag == null).to.equal(true);
+    });
+
 });


### PR DESCRIPTION
__Problem:__
Some developers have run into issues because the same module was installed multiple times in their project with different versions. Currently, Marko just walks up the directory tree to discover and load taglibs and it will happily load multiple versions of the same taglib and this can lead to unexpected results.

__Solution:__
Improve the logic of assigning an ID to a taglib such that only one version of a taglib is loaded. The taglib ID will now match the "name" found in the `package.json` found next to the `marko-taglib.json` (if it exists) and we also now allow an ID to be assigned using the `taglib-id` property in a `marko-tag.json` file. Taglibs closer to a template (in the directory tree) will take precedence over taglibs farther away.