### PR TITLE
Invalidate cache before requiring changed template

### DIFF
--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -53,6 +53,7 @@ module.exports = function load(templatePath) {
     fs.writeFileSync(tempFile, compiledSrc, fsReadOptions);
     fs.renameSync(tempFile, targetFile);
 
+    delete require.cache[require.resolve(targetFile)];
     return require(targetFile);
 };
 

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -53,7 +53,7 @@ module.exports = function load(templatePath) {
     fs.writeFileSync(tempFile, compiledSrc, fsReadOptions);
     fs.renameSync(tempFile, targetFile);
 
-    delete require.cache[require.resolve(targetFile)];
+    delete require.cache[targetFile];
     return require(targetFile);
 };
 


### PR DESCRIPTION
`marko.load` checks if template is up to date and, if not, it compiles,
saves, and requires it again. However, it saves it under the same name
as the old template, so just requiring it again hits the module cache
and returns the compiled template.

Fix by deleting old template from module cache before re-requiring.

Failing test case:

    var fs = require('fs'),
        marko = require('marko'),
        data = { what: 'world' };

    fs.writeFileSync('test.marko', 'hello, ${data.what}!');
    marko.load('test.marko').render(data, function(err, out) {
        console.log(out); // prints "hello, world"

        fs.writeFileSync('test.marko', 'goodbye, ${data.what}!');
        marko.load('test.marko').render(data, function(err, out) {
            console.log(out); // prints "hello, world" again
        });
    });